### PR TITLE
[FS04] Add stub DevAgent and package init

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,1 @@
+"""CAP-X agent package."""

--- a/agents/dev_agent.py
+++ b/agents/dev_agent.py
@@ -1,0 +1,20 @@
+"""Stub DevAgent implementation for CAP-X.
+
+This module provides a minimal DevAgent placeholder to allow
+importing the package before the real logic is added. It will be
+filled out in FS12.
+"""
+
+
+class DevAgent:
+    """Minimal development agent stub."""
+
+    def __init__(self) -> None:
+        self.name = "DevAgent (stub)"
+
+    def run(self, prompt: str) -> str:
+        """Return a placeholder response."""
+        return "\U0001f6e0\ufe0f  DevAgent stub here \u2013 implement me in FS12!"
+
+
+# python -c "from agents.dev_agent import DevAgent; print(DevAgent().run('hi'))"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+ruff
+black


### PR DESCRIPTION
Implements FS04 (see configs/ROADMAP_TODO.md).
Adds agents/__init__.py and agents/dev_agent.py.
Smoke-test: python -c "from agents.dev_agent import DevAgent; print(DevAgent().run('hello'))"
Expected output: 🛠️  DevAgent stub here – implement me in FS12!
