### PR TITLE
[FS09–10] Add MCP launch scripts and close FS04

### DIFF
--- a/configs/ROADMAP_TODO.md
+++ b/configs/ROADMAP_TODO.md
@@ -16,8 +16,8 @@ Legend
 <!-- TASK:FS03 status=done -->
 - [x] **FS03 – Create base folders** — `agents/ mcp_servers/ configs/ reports/ scripts/` committed (with `.gitkeep`).
 
-<!-- TASK:FS04 status=pending -->
-- [ ] **FS04 – Stub `dev_agent.py`** — add minimal `DevAgent` class (google-adk, no tools yet); must import cleanly.
+<!-- TASK:FS04 status=done -->
+- [x] **FS04 – Stub `dev_agent.py`** — add minimal `DevAgent` class (google-adk, no tools yet); must import cleanly.
 
 <!-- TASK:FS05 status=done -->
 - [x] **FS05 – Add AGENTS.md** — brief agent catalogue & contribution tips.

--- a/mcp_servers/run_filesystem.sh
+++ b/mcp_servers/run_filesystem.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Launch the local Filesystem MCP on port 8787
+
+set -euo pipefail
+npx --yes --quiet @modelcontextprotocol/server-filesystem /workspace 8787

--- a/mcp_servers/run_github.sh
+++ b/mcp_servers/run_github.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Launch the local GitHub MCP on port 8788 (uses \$GITHUB_PERSONAL_ACCESS_TOKEN)
+
+set -euo pipefail
+: "${GITHUB_PERSONAL_ACCESS_TOKEN:?Need this env var}"
+npx --yes --quiet @modelcontextprotocol/server-github 8788


### PR DESCRIPTION
## Summary
Add helpers to launch local MCP servers and mark FS04 complete.

## Changes
- mark FS04 as done in the roadmap
- add `run_filesystem.sh` and `run_github.sh` launchers

## Testing
```bash
ruff check --fix .
black . --check
bandit -r .  # fails: command not found
```
