### PR TITLE
[FS14] Add CI bootstrap workflow (Ubuntu + macOS)

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,31 @@
+name: bootstrap
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  lint-matrix:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run project bootstrap
+        run: |
+          chmod +x scripts/bootstrap.sh
+          scripts/bootstrap.sh
+
+      - name: Ruff lint
+        run: ruff check .
+
+      - name: Black formatting (check mode)
+        run: black --check .
+
+      - name: Bandit security scan
+        run: bandit -r .

--- a/configs/ROADMAP_TODO.md
+++ b/configs/ROADMAP_TODO.md
@@ -46,8 +46,8 @@ Legend
 <!-- TASK:FS13 status=pending -->
 - [ ] **FS13 – Agent docstring** — explain extension points & tool wiring in `dev_agent.py`.
 
-<!-- TASK:FS14 status=pending -->
-- [ ] **FS14 – CI bootstrap workflow** — `.github/workflows/bootstrap.yml` (macOS + Ubuntu) runs bootstrap.
+<!-- TASK:FS14 status=done -->
+- [x] **FS14 – CI bootstrap workflow** — `.github/workflows/bootstrap.yml` (macOS + Ubuntu) runs bootstrap.
 
 <!-- TASK:FS15 status=pending -->
 - [ ] **FS15 – Roadmap parser** — code that lists `status=pending` tasks from this file.


### PR DESCRIPTION
## Summary
Implements FS14 – adds a matrix GitHub Actions workflow that:
* runs `scripts/bootstrap.sh`
* lints with Ruff & Black
* runs Bandit security scan

## Changes
* `.github/workflows/bootstrap.yml` – new workflow
* `configs/ROADMAP_TODO.md` – marks FS14 as done ✓

## Testing
```bash
ruff check . && black --check . && bandit -r .
All commands exit 0 locally; CI passes on both runners.
