### PR TITLE
[FS14] add bootstrap workflow

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,23 @@
+name: bootstrap
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  bootstrap:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run bootstrap
+        shell: bash
+        run: scripts/bootstrap.sh
+      - name: Run checks
+        shell: bash
+        run: |
+          ruff check .
+          black --check .
+          bandit -r .

--- a/configs/ROADMAP_TODO.md
+++ b/configs/ROADMAP_TODO.md
@@ -46,8 +46,8 @@ Legend
 <!-- TASK:FS13 status=pending -->
 - [ ] **FS13 – Agent docstring** — explain extension points & tool wiring in `dev_agent.py`.
 
-<!-- TASK:FS14 status=pending -->
-- [ ] **FS14 – CI bootstrap workflow** — `.github/workflows/bootstrap.yml` (macOS + Ubuntu) runs bootstrap.
+<!-- TASK:FS14 status=done -->
+- [x] **FS14 – CI bootstrap workflow** — `.github/workflows/bootstrap.yml` (macOS + Ubuntu) runs bootstrap.
 
 <!-- TASK:FS15 status=pending -->
 - [ ] **FS15 – Roadmap parser** — code that lists `status=pending` tasks from this file.


### PR DESCRIPTION
## Summary
Add CI workflow running the project bootstrap script and code checks on both
Ubuntu and macOS runners.

## Changes
- new `.github/workflows/bootstrap.yml`
- mark FS14 done in `configs/ROADMAP_TODO.md`
- make `scripts/bootstrap.sh` executable

## Testing
```bash
ruff check --fix .
black . --check
bandit -r .
```
All checks passed.

## References

Closes FS14