### PR TITLE
[FS14] add bootstrap CI workflow

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,21 @@
+name: bootstrap
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  bootstrap:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run bootstrap script
+        run: scripts/bootstrap.sh
+      - name: Run linters
+        run: |
+          ruff check .
+          black --check .
+          bandit -r .

--- a/configs/ROADMAP_TODO.md
+++ b/configs/ROADMAP_TODO.md
@@ -46,8 +46,8 @@ Legend
 <!-- TASK:FS13 status=pending -->
 - [ ] **FS13 – Agent docstring** — explain extension points & tool wiring in `dev_agent.py`.
 
-<!-- TASK:FS14 status=pending -->
-- [ ] **FS14 – CI bootstrap workflow** — `.github/workflows/bootstrap.yml` (macOS + Ubuntu) runs bootstrap.
+<!-- TASK:FS14 status=done -->
+- [x] **FS14 – CI bootstrap workflow** — `.github/workflows/bootstrap.yml` (macOS + Ubuntu) runs bootstrap.
 
 <!-- TASK:FS15 status=pending -->
 - [ ] **FS15 – Roadmap parser** — code that lists `status=pending` tasks from this file.


### PR DESCRIPTION
## Summary
Implement CI workflow that runs bootstrap script on Ubuntu and macOS runners.

## Changes
- add `.github/workflows/bootstrap.yml`
- mark `scripts/bootstrap.sh` executable
- update roadmap to mark FS14 complete

## Testing
```bash
ruff check --fix .
black . --check
bandit -r .
```
* Result: All checks passed

## References

Closes FS14