### PR TITLE
[FS14] Add bootstrap CI workflow

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -1,0 +1,24 @@
+name: bootstrap
+
+on: [push, pull_request]
+
+jobs:
+  bootstrap:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Ensure bootstrap executable
+        run: chmod +x scripts/bootstrap.sh
+        shell: bash
+      - name: Run bootstrap
+        run: scripts/bootstrap.sh
+        shell: bash
+      - name: Run linters
+        run: |
+          ruff check .
+          black --check .
+          bandit -r .
+        shell: bash

--- a/configs/ROADMAP_TODO.md
+++ b/configs/ROADMAP_TODO.md
@@ -46,8 +46,8 @@ Legend
 <!-- TASK:FS13 status=pending -->
 - [ ] **FS13 – Agent docstring** — explain extension points & tool wiring in `dev_agent.py`.
 
-<!-- TASK:FS14 status=pending -->
-- [ ] **FS14 – CI bootstrap workflow** — `.github/workflows/bootstrap.yml` (macOS + Ubuntu) runs bootstrap.
+<!-- TASK:FS14 status=done -->
+- [x] **FS14 – CI bootstrap workflow** — `.github/workflows/bootstrap.yml` (macOS + Ubuntu) runs bootstrap.
 
 <!-- TASK:FS15 status=pending -->
 - [ ] **FS15 – Roadmap parser** — code that lists `status=pending` tasks from this file.


### PR DESCRIPTION
## Summary
Add cross-platform CI workflow for running bootstrap and linters.

## Changes
- mark FS14 done in ROADMAP_TODO
- create `.github/workflows/bootstrap.yml`
- set `scripts/bootstrap.sh` as executable

## Testing
```bash
ruff check .
black --check .
bandit -r .
```
All tests pass.

## References

Closes FS14