### PR TITLE
fix: (FS14) ensure bootstrap env and script modes

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -28,6 +28,7 @@ elif [[ "$OS" == "Darwin" ]]; then
     for pkg in python3 node; do
       brew list "$pkg" >/dev/null 2>&1 || brew install "$pkg"
     done
+    export PIP_BREAK_SYSTEM_PACKAGES=1  # macOS Homebrew pip guard (PEP 668)
   else
     echo "❌  Homebrew not found; install python3 & node manually." >&2
     exit 1


### PR DESCRIPTION
## Summary
Fixes CI issues with macOS pip and shell script permissions.

## Changes
- set `PIP_BREAK_SYSTEM_PACKAGES=1` in macOS block of `bootstrap.sh`
- mark bootstrap and MCP scripts as executable
- one-line patch plus mode changes

## Testing
```bash
ruff check --fix .
black . --check
bandit -r .
```
All checks passed.

## References

Closes FS14