### PR TITLE
[FS15] add prompt template README

### DIFF
--- a/DEEP_RESEARCH.md
+++ b/DEEP_RESEARCH.md
@@ -162,5 +162,9 @@ Updated 2025-05-20
   Create the feature branch in the *implementation* prompt to keep SOP stages atomic.
 - **Codex Push controls** – branches created inside a Codex task and prefixed  
   `codex/…` automatically expose the **Push ▾ / Create PR** buttons.
-  If a task ends with “unknown error” but a commit exists, run a no-op follow-up  
+  If a task ends with “unknown error” but a commit exists, run a no-op follow-up
   task (or use the Push menu) to surface the diff and push the branch.
+
+See **docs/prompt_templates/README.md** for copy-paste instructions.  
+For long prompts, generate a downloadable `.txt` via `python_user_visible`
+to bypass ChatGPT UI escaping.

--- a/docs/prompt_templates/README.md
+++ b/docs/prompt_templates/README.md
@@ -1,0 +1,13 @@
+# How to use Prompt Templates
+
+1. Open the template (assumptions_check.md or tasking.md)  
+2. Copy **exactly** the raw text — do **not** wrap it in outer code fences.  
+3. Paste into a new Codex task.  
+4. After Codex replies **DONE**, click **Push ▾ / Create PR**.
+
+### Large prompts
+
+For long or complex prompts, generate a `.txt` file with
+`python_user_visible` and share the download link.  
+The human copies the file’s contents verbatim into Codex, avoiding UI
+escaping and comment‑prefix issues.


### PR DESCRIPTION
## Summary
Add instructions on how to copy/paste prompt templates and reference them from the SOP.

## Changes
- create `docs/prompt_templates/README.md`
- mention template instructions in `DEEP_RESEARCH.md`

## Testing
```bash
ruff check --fix .
black .
bandit -r .
```
All checks passed.

## References

Closes FS15