### PR TITLE
Add prompt templates

### DIFF
--- a/DEEP_RESEARCH.md
+++ b/DEEP_RESEARCH.md
@@ -151,6 +151,12 @@ Prompt Codex to write a brief debrief:
 
 8 Future Enhancements
 
+## Prompt Templates
+Templates live in **docs/prompt_templates**:  
+* assumptions_check.md – run on `main`; verify repo state; obtain current Codex setup script first.  
+* tasking.md – branch `codex/…`, patches, commit, `echo DONE`.  
+Generate prompts as downloadable `.txt` files (python_user_visible) with **no narrative** to avoid UI escaping issues.
+
 * Add a CI job to automatically check assumptions drift
 * Build memory tooling for summarizing agent debriefs
 * Support Codex running in headless mode with env and SOP preloaded

--- a/docs/prompt_templates/assumptions_check.md
+++ b/docs/prompt_templates/assumptions_check.md
@@ -1,0 +1,19 @@
+# Assumptions\-Check Prompt Template
+
+```
+# <Task name> — assumptions check
+| # | Assumption to verify |
+|---|----------------------|
+| 1 | main CI is green |
+| 2 | … |
+
+Return:
+
+| # | TRUE/FALSE | Evidence | Notes if FALSE |
+```
+
+**Guidelines**
+- Run on `main`; do **not** create or mention branches.
+- No file edits; output table only.
+- Provide this prompt as a downloadable .txt via python_user_visible.
+- Before running, obtain the current Codex environment‑setup script from the human collaborator.

--- a/docs/prompt_templates/tasking.md
+++ b/docs/prompt_templates/tasking.md
@@ -1,0 +1,23 @@
+# Implementation / Tasking Prompt Template
+
+```
+git checkout -b codex/<feature-branch>
+
+## Patch blocks
+apply_patch <file> <<'PATCH'
+...
+PATCH
+
+## Commit
+git add …
+git commit -m "<type>: <summary> (<task id>)"
+
+echo DONE   # clean exit; human will Push ▾ / Create PR
+```
+
+### Roadmap variant
+Start with:
+
+```
+python scripts/parse_roadmap.py --format json > /tmp/tasks.json
+```


### PR DESCRIPTION
## Summary
Add SOP documentation for prompt templates.

## Changes
- add assumptions_check.md and tasking.md
- document prompts in DEEP_RESEARCH.md

## Testing
```bash
ruff check --fix .
black --check .
bandit -r .
```
All checks passed.
